### PR TITLE
Set javadoc encoding to utf-8 (#50)

### DIFF
--- a/java-client/build.gradle.kts
+++ b/java-client/build.gradle.kts
@@ -74,6 +74,12 @@ tasks.withType<ProcessResources> {
     )
 }
 
+tasks.withType<Javadoc>().configureEach{
+    options {
+        encoding = "UTF-8"
+    }
+}
+
 tasks.withType<Jar> {
     doFirst {
         if (rootProject.extra.has("gitHashFull")) {


### PR DESCRIPTION
Set javadoc encoding to utf-8. This resolve issue: https://github.com/opensearch-project/opensearch-java/issues/50